### PR TITLE
BLD: ban caproto version 0.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bluesky
-caproto[complete]
+caproto[complete] !=0.2.3
 dask
 databroker
 distributed


### PR DESCRIPTION
This version of caproto makes unconditional use of a feature in the
socket module that may or may not be there depending on the kernel
version on the machine that compiled the cpython binary.

In particular recent builds of cpython from conda are built on a
sufficiently old kernel that the reuse_port option is not available.