### PR TITLE
Resolve JupyterHub<0.9.6 vulnerability warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ tornado<5
 pip<19
 
 # Careful: Changing these could break the cluster.
-jupyterhub==0.8.*
+jupyterhub>=0.9.6
 nbgitpuller


### PR DESCRIPTION
This PR attempts to resolve the following issue:
![Screenshot_2019-04-03 NSLS-II tutorial](https://user-images.githubusercontent.com/13209176/55452177-722c1580-55a4-11e9-8344-f57fd148cadf.png)


The mybinder env worked fine after applying the same fix to another tutorial in https://github.com/mrakitin/Berlin-2019-bluesky-tutorial/commit/512ae18d3c34b39985f2af518b9b65b553e0b12f.