### PR TITLE
ENH: define $DIR the same way in all shell scripts

### DIFF
--- a/tutorials/supervisor/monitor_supervisor.sh
+++ b/tutorials/supervisor/monitor_supervisor.sh
@@ -4,6 +4,6 @@
 # start time (i.e. ENTRYPOINT). If supervisord has been run, this could be used
 # to monitor its status and no action will be required by the user.
 
-DIR=`dirname "\$0"`
+DIR=$( cd "$(dirname "$0")" ; pwd -P )
 
 supervisorctl -c $DIR/supervisord.conf status

--- a/tutorials/supervisor/start_supervisor.sh
+++ b/tutorials/supervisor/start_supervisor.sh
@@ -4,7 +4,7 @@
 # start time (i.e. ENTRYPOINT) then we can run this that way and
 # no action will be required by the user.
 
-DIR=`dirname "\$0"`
+DIR=$( cd "$(dirname "$0")" ; pwd -P )
 
 [ ! -e /tmp/supervisor.sock ] && supervisord -c $DIR/supervisord.conf
 supervisorctl -c $DIR/supervisord.conf status


### PR DESCRIPTION
Following the suggestion in #20, here are a couple more places where `$DIR` is defined. Credits to https://stackoverflow.com/a/4774063/4143531.